### PR TITLE
Bump JDK 21 from 21.0.0 to 21.0.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -185,15 +185,14 @@ api = "0.7"
     id = "jdk"
     name = "Microsoft OpenJDK"
     purl = "pkg:generic/microsoft/openjdk@21.0.0"
-    sha256 = "6d923554717e281cd0b2e13b11de90dab34e5fc4026f5661e9bbf42ce415d9fe"
+    sha256 = "01ebc38576660b61cc45fdadb7f1cc59278d0284ef999c98ed8bc55c8946cbf4"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://aka.ms/download-jdk/microsoft-jdk-17.0.8.1-linux-x64.tar.gz"
+    uri = "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-linux-x64.tar.gz"
     version = "21.0.0"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"
       uri = "https://openjdk.java.net/legal/gplv2+ce.html"
-  
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
Bumps `JDK 21` from `21.0.0` to `21.0.0`.